### PR TITLE
Added Js.String.concatMany benchmark

### DIFF
--- a/src/Suites.re
+++ b/src/Suites.re
@@ -52,6 +52,11 @@ loop("", strings);|j},
       f: (.) => Any(stringsArr |> Js.Array.joinWith("")),
       code: {j|stringsArr |> Js.Array.joinWith("");|j},
     },
+    {
+      name: "Js.String.concatMany",
+      f: (.) => Any(stringsArr->Js.String.concatMany("")),
+      code: {j|stringsArr->Js.String.concatMany("");|j},
+    }
   |];
 
   let name = "Concatenate 100 strings";


### PR DESCRIPTION
Thanks for the great project.

This PR adds an alternative to "Concatenate 100 strings" suite.
For string concatenation, `concatMany` would be a fair comparison target.
(The result is pretty impressive that `Pervasives.(++)` still outperforms idiomatic JS)